### PR TITLE
fix(harness): the dev server runs in the clone that opened it (#2)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
         {
             "name": "devindex-dev-server",
             "runtimeExecutable": "npm",
-            "runtimeArgs": ["--prefix", "/Users/Shared/github/neomjs/devindex", "run", "server-start"],
+            "runtimeArgs": ["run", "server-start"],
             "port": 8080,
             "autoPort": true
         }


### PR DESCRIPTION
Resolves #2

`.claude/launch.json` pinned the dev server to one absolute path via `--prefix`. Every maintainer has a separate workspace root, so for anyone whose clone is not that path the preview did not fail — **it started and served a different checkout**. Your edits invisible, someone else's uncommitted state rendering, and nothing in the output saying so.

That is the same false-green class `neomjs/neo`'s e2e config warns about when it sets `reuseExistingServer: false`: a server that satisfies the readiness URL while serving the wrong tree produces false reds and, worse, false greens.

Evidence: L2 (the server's own reported content root, from a real launch using the changed command shape) → L2 required (the property is "which directory does the process serve", which the process itself reports).

## The fix

`server-start` is root-relative and needs no prefix — npm already runs it in the package directory, which is the clone the harness opened.

```diff
- "runtimeArgs": ["--prefix", "/Users/Shared/github/neomjs/devindex", "run", "server-start"],
+ "runtimeArgs": ["run", "server-start"],
```

## Test Evidence

Verified by the server's own reported content root rather than by reasoning about npm semantics. Launched with the new cwd-relative shape from a clone that is **not** the previously hardcoded one:

```
[WebServer] <i> [webpack-dev-server] Content not from webpack is served from
            '/Users/Shared/claude/neomjs/devindex' directory
```

That is the clone that started it. Under the old form the same launch would have served `/Users/Shared/github/neomjs/devindex` regardless of where it was invoked, which is the property being repaired.

The app boots and renders from that root — the grid, its 37 columns and its data all come from the serving clone.

## Acceptance Criteria

- [x] `.claude/launch.json` contains no absolute filesystem path
- [x] Starting the preview from a clone at any root serves **that** clone — verified by the server's reported content root
- [x] Two clones can run the preview without both resolving to the same directory — the command carries no path at all, so each resolves to its own

## Base branch

Targets `main` on the operator's explicit direction (2026-08-20): *"we could create a dev branch there too. or merge PRs to main."* This repository has only `main`, its CI triggers on `push: [main]` plus `pull_request`, and it has no release line for `main` to protect — so `neomjs/neo`'s "agent PRs target `dev`" gate, which exists to protect that release line, has nothing to guard here. Recorded rather than assumed, so the next PR does not have to re-derive it.

## Out of Scope

- Port-collision handling between simultaneous previews; `autoPort` already covers the port, and the directory was the defect
- Any change to `server-start` itself

Authored by Grace (Claude Opus 5, Claude Code). Session 3e4f33e0-fb23-4a61-a2a0-7f396950f3d6.
