### PR TITLE
feat(test): the e2e suite this app needs, in the repo that owns it (neomjs/neo#17422)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "devindex:update"                      : "node ./apps/devindex/services/cli.mjs update --limit 200",
         "generate-docs-json"                   : "node ./node_modules/neo.mjs/buildScripts/docs/jsdocx.mjs",
         "server-start"                         : "webpack serve -c ./node_modules/neo.mjs/buildScripts/webpack/webpack.server.config.mjs --open",
+        "test-e2e"                            : "playwright test -c test/playwright/playwright.config.e2e.mjs",
         "test-unit"                            : "playwright test -c test/playwright/playwright.config.unit.mjs",
         "watch-themes"                         : "node ./node_modules/neo.mjs/buildScripts/helpers/watchThemes.mjs"
     },

--- a/test/playwright/e2e/benchmarks/GridProfile.spec.mjs
+++ b/test/playwright/e2e/benchmarks/GridProfile.spec.mjs
@@ -1,0 +1,116 @@
+import { test } from '@playwright/test';
+
+const viewports = [
+    { name: 'Mobile',  width: 375,  height: 667 },
+    { name: 'Laptop',  width: 1366, height: 768 },
+    { name: 'Desktop', width: 1920, height: 1080 }
+];
+
+viewports.forEach(({ name, width, height }) => {
+    test.describe(`${name} (${width}x${height}): Grid Profiler`, () => {
+        test.use({ viewport: { width, height } });
+
+        test('Profile Main Thread during Scroll', async ({ page }) => {
+            // Increase timeout for profiling
+            test.setTimeout(120000);
+
+            await page.goto('/apps/devindex/');
+            await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
+
+            // Wait for streaming to finish
+            const stopButton = page.locator('.devindex-stop-stream-button');
+            await stopButton.waitFor({ state: 'visible', timeout: 5000 });
+            await stopButton.waitFor({ state: 'hidden', timeout: 60000 });
+            await page.waitForTimeout(2000);
+
+            // Setup CDP Session for Tracing
+            const client = await page.context().newCDPSession(page);
+            await client.send('Tracing.start', {
+                traceConfig: {
+                    includedCategories: [
+                        'devtools.timeline',
+                        'v8.execute',
+                        'disabled-by-default-devtools.timeline',
+                        'disabled-by-default-devtools.timeline.frame',
+                        'toplevel',
+                        'blink.console',
+                        'blink.user_timing',
+                        'latencyInfo',
+                        'disabled-by-default-devtools.timeline.stack'
+                    ]
+                }
+            });
+
+            console.log(`[${name}] --- Profiling Started ---`);
+
+            // --- SCROLL ACTION ---
+            await page.evaluate(async () => {
+                const scrollable = document.querySelector('.neo-grid-container');
+                if (!scrollable) throw new Error('Scroll container not found');
+
+                const maxScroll = scrollable.scrollWidth - scrollable.clientWidth;
+                const steps     = 40;
+                const delay     = 32; // ~30 FPS cadence
+
+                // Scroll Right
+                for (let i = 0; i <= steps; i++) {
+                    scrollable.scrollLeft = (maxScroll / steps) * i;
+                    await new Promise(r => setTimeout(r, delay));
+                }
+                // Scroll Left
+                for (let i = steps; i >= 0; i--) {
+                    scrollable.scrollLeft = (maxScroll / steps) * i;
+                    await new Promise(r => setTimeout(r, delay));
+                }
+            });
+            // ---------------------
+
+            console.log(`[${name}] --- Profiling Ended ---`);
+
+            const traceEvents = [];
+            client.on('Tracing.dataCollected', (event) => {
+                traceEvents.push(...event.value);
+            });
+
+            await new Promise(resolve => {
+                client.on('Tracing.tracingComplete', resolve);
+                client.send('Tracing.end');
+            });
+
+            // --- ANALYSIS ---
+            // Simple bucket aggregation
+            const categories = {
+                'Scripting': ['RunTask', 'FunctionCall', 'EvaluateScript', 'v8.execute'],
+                'Layout'   : ['UpdateLayoutTree', 'Layout', 'HitTest'],
+                'Painting' : ['UpdateLayerTree', 'Paint', 'CompositeLayers'],
+                'System'   : []
+            };
+
+            const stats = {
+                'Scripting': 0,
+                'Layout'   : 0,
+                'Painting' : 0,
+                'Other'    : 0
+            };
+
+            // Helper to find category
+            const getCategory = (name) => {
+                if (categories.Scripting.includes(name)) return 'Scripting';
+                if (categories.Layout.includes(name)) return 'Layout';
+                if (categories.Painting.includes(name)) return 'Painting';
+                return 'Other';
+            };
+
+            traceEvents.forEach(e => {
+                if (e.ph === 'X') { // Complete Event
+                    const duration = e.dur / 1000; // microseconds to ms
+                    const cat      = getCategory(e.name);
+                    stats[cat] += duration;
+                }
+            });
+
+            console.log(`\n[${name}] --- CPU Time Breakdown (ms) ---`);
+            console.table(stats);
+        });
+    });
+});

--- a/test/playwright/e2e/benchmarks/GridScrollBenchmark.spec.mjs
+++ b/test/playwright/e2e/benchmarks/GridScrollBenchmark.spec.mjs
@@ -1,6 +1,31 @@
 import { test, expect }         from '@playwright/test';
 import { measureJankInBrowser } from '../utils/browser-test-helpers.mjs';
 
+/**
+ * @summary Witness that the data stream stops. **It does not benchmark, and it does not scroll.**
+ *
+ * Measured on the current tree, not inferred — this file is vacuous in two independent ways, and
+ * both predate the move to this repository (the same code and the same condition are on the engine's
+ * `dev`):
+ *
+ * 1. **The scroll never happens.** The horizontal case reads `maxScroll` off `.neo-grid-container`,
+ *    but that element is not the scroll container — the grid drives horizontal movement through its
+ *    own scroll manager and a custom scrollbar, so `scrollWidth - clientWidth` is `0` and the body
+ *    returns `{skipped: true, reason: 'Not scrollable'}` before touching anything. Verified at every
+ *    viewport, Mobile through Desktop.
+ * 2. **The measurement is commented out.** `measureJankInBrowser` is injected into the page and never
+ *    invoked; the callback returns a literal instead.
+ *
+ * The result was previously published as a `benchmark-native-horizontal` annotation. A skip constant
+ * carried under a benchmark type is worse than no benchmark: it reads as a datum in the report and
+ * cannot move, so nothing about it can ever fail.
+ *
+ * Left dormant rather than repaired here. Re-pointing the scroll target and re-enabling the
+ * instrument is a behaviour change, and shipping one inside a repository migration would hide it
+ * under a move. The `beforeEach` stream-stop assertions are real and still run, which is what this
+ * file honestly is today.
+ */
+
 const viewports = [
     { name: 'Mobile',  width: 375,  height: 667 },
     { name: 'Laptop',  width: 1366, height: 768 },
@@ -92,9 +117,13 @@ viewports.forEach(({ name, width, height }) => {
                 return { success: true }; // await measurementPromise;
             });
 
-            console.log(`[${name}] Native Horizontal:`, scrollResult);
+            console.log(`[${name}] Native Horizontal (completion only, no timing):`, scrollResult);
+
+            // Annotated as `witness`, not `benchmark`. `scrollResult` is the constant `{success: true}`
+            // while the jank measurement above is dormant, and a constant published under a benchmark
+            // type reads as a datum in the report while being incapable of moving.
             test.info().annotations.push({
-                type       : 'benchmark-native-horizontal',
+                type       : 'witness-native-horizontal-scroll-completed',
                 description: JSON.stringify({ viewport: name, ...scrollResult })
             });
         });

--- a/test/playwright/e2e/benchmarks/GridScrollBenchmark.spec.mjs
+++ b/test/playwright/e2e/benchmarks/GridScrollBenchmark.spec.mjs
@@ -16,14 +16,21 @@ import { measureJankInBrowser } from '../utils/browser-test-helpers.mjs';
  * 2. **The measurement is commented out.** `measureJankInBrowser` is injected into the page and never
  *    invoked; the callback returns a literal instead.
  *
- * The result was previously published as a `benchmark-native-horizontal` annotation. A skip constant
- * carried under a benchmark type is worse than no benchmark: it reads as a datum in the report and
- * cannot move, so nothing about it can ever fail.
+ * The result was previously published as a `benchmark-native-horizontal` annotation on a **passing**
+ * test. A skip constant carried under a benchmark type is worse than no benchmark: it reads as a
+ * datum in the report and cannot move, so nothing about it can ever fail.
+ *
+ * So the horizontal cases are now marked `fixme` when the skip fires, and are reported as **known
+ * missing coverage** rather than as passes. Renaming the annotation was not enough and was the wrong
+ * repair: a skipped operation cannot witness completion under any label.
+ *
+ * The `fixme` is conditional and evaluated inside the test rather than at declaration, so the
+ * `beforeEach` stream-stop assertions still execute and can still fail — those exercise the app for
+ * real and are the only genuine coverage this file currently carries.
  *
  * Left dormant rather than repaired here. Re-pointing the scroll target and re-enabling the
  * instrument is a behaviour change, and shipping one inside a repository migration would hide it
- * under a move. The `beforeEach` stream-stop assertions are real and still run, which is what this
- * file honestly is today.
+ * under a move.
  */
 
 const viewports = [
@@ -117,13 +124,26 @@ viewports.forEach(({ name, width, height }) => {
                 return { success: true }; // await measurementPromise;
             });
 
-            console.log(`[${name}] Native Horizontal (completion only, no timing):`, scrollResult);
+            console.log(`[${name}] Native Horizontal:`, scrollResult);
 
-            // Annotated as `witness`, not `benchmark`. `scrollResult` is the constant `{success: true}`
-            // while the jank measurement above is dormant, and a constant published under a benchmark
-            // type reads as a datum in the report while being incapable of moving.
+            // Reported as dormant rather than passing. The scroll target is wrong, so this case
+            // returns before moving anything — and a skipped operation is MISSING COVERAGE, not
+            // evidence. Passing it green (under any annotation name) is the false-green this file's
+            // docblock diagnoses; renaming the annotation does not make a skip into a witness.
+            //
+            // `fixme` is evaluated here rather than at declaration so the `beforeEach` stream-stop
+            // assertions — which are real and do exercise the app — still run and can still fail.
+            test.fixme(
+                scrollResult.skipped === true,
+                `Native horizontal scroll did not execute: ${scrollResult.reason}. ` +
+                '`.neo-grid-container` is not the horizontal scroll container — the grid moves ' +
+                'through its own scroll manager and a custom scrollbar. Repairing the target and ' +
+                're-enabling `measureJankInBrowser` is a behaviour change and belongs in its own ' +
+                'reviewable commit, not inside a repository migration.'
+            );
+
             test.info().annotations.push({
-                type       : 'witness-native-horizontal-scroll-completed',
+                type       : 'benchmark-native-horizontal',
                 description: JSON.stringify({ viewport: name, ...scrollResult })
             });
         });

--- a/test/playwright/e2e/benchmarks/GridScrollBenchmark.spec.mjs
+++ b/test/playwright/e2e/benchmarks/GridScrollBenchmark.spec.mjs
@@ -1,0 +1,102 @@
+import { test, expect }         from '@playwright/test';
+import { measureJankInBrowser } from '../utils/browser-test-helpers.mjs';
+
+const viewports = [
+    { name: 'Mobile',  width: 375,  height: 667 },
+    { name: 'Laptop',  width: 1366, height: 768 },
+    { name: 'Desktop', width: 1920, height: 1080 }
+];
+
+viewports.forEach(({ name, width, height }) => {
+    test.describe(`${name} (${width}x${height}): DevIndex Native Scroll Benchmarks`, () => {
+
+        test.use({ viewport: { width, height } });
+
+        test.beforeEach(async ({ page }) => {
+            // Inject helpers
+            await page.addInitScript({
+                content: `
+                    window.measureJankInBrowser = ${measureJankInBrowser.toString()};
+                `
+            });
+
+            await page.goto('/apps/devindex/');
+
+            // 1. Wait for the grid to be visible
+            await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
+
+            // 2. Wait for the streaming to start (Stop button visible)
+            const stopButton = page.locator('.devindex-stop-stream-button');
+            await expect(stopButton).toBeVisible({ timeout: 5000 });
+
+            console.log(`[${name}] Streaming started...`);
+
+            // 3. Wait for the streaming to finish (Stop button hidden)
+            await expect(stopButton).toBeHidden({ timeout: 60000 });
+
+            console.log(`[${name}] Streaming finished.`);
+
+            // 4. Wait for the UI to settle (buffer time)
+            await page.waitForTimeout(1000);
+
+            // 5. CRITICAL: Disconnect Neo's Mutation Observer to remove test artifact overhead
+            await page.evaluate(() => {
+                if (Neo.main.DomAccess.documentMutationObserver) {
+                    Neo.main.DomAccess.documentMutationObserver.disconnect();
+                    console.log('Neo.main.DomAccess.documentMutationObserver disconnected for benchmark.');
+                } else {
+                    console.warn('Neo.main.DomAccess.documentMutationObserver was not found.');
+                }
+            });
+        });
+
+        test('Horizontal Scroll (Native Smooth)', async ({ page }) => {
+            const scrollResult = await page.evaluate(async () => {
+                // Horizontal scroll is on the neo-grid-container
+                const scrollable = document.querySelector('.neo-grid-container');
+                if (!scrollable) throw new Error('Horizontal scroll container not found');
+
+                const maxScroll = scrollable.scrollWidth - scrollable.clientWidth;
+                if (maxScroll <= 0) return { skipped: true, reason: 'Not scrollable' };
+
+                const performScroll = async () => {
+                    // Trigger native smooth scroll
+                    scrollable.scrollTo({
+                        left    : maxScroll,
+                        behavior: 'smooth'
+                    });
+
+                    // Wait for the scroll to complete.
+                    // Since 'scrollend' event support is spotty in some environments or might be flaky in tests,
+                    // we use a simple polling or fixed timeout.
+                    // A full width scroll takes time, let's give it 2.5s matching measurement window.
+                    await new Promise(r => setTimeout(r, 2500));
+
+                    // Verify scroll actually happened
+                    if (scrollable.scrollLeft < 100) {
+                        throw new Error(`Scroll failed! Expected scrollLeft > 100, got ${scrollable.scrollLeft}`);
+                    }
+
+                    // Scroll back
+                    scrollable.scrollTo({
+                        left    : 0,
+                        behavior: 'smooth'
+                    });
+
+                    await new Promise(r => setTimeout(r, 2500));
+                };
+
+                // Measure over 5 seconds (2.5s out, 2.5s back)
+                // const measurementPromise = window.measureJankInBrowser(5000);
+                await performScroll();
+                return { success: true }; // await measurementPromise;
+            });
+
+            console.log(`[${name}] Native Horizontal:`, scrollResult);
+            test.info().annotations.push({
+                type       : 'benchmark-native-horizontal',
+                description: JSON.stringify({ viewport: name, ...scrollResult })
+            });
+        });
+    });
+});

--- a/test/playwright/e2e/gl.setup.mjs
+++ b/test/playwright/e2e/gl.setup.mjs
@@ -1,0 +1,63 @@
+import {test as setup, expect}                   from '@playwright/test';
+import {activeLaunchArgs, claimsGpuAcceleration} from './utils/gpuIntent.mjs';
+import {readGlState}                             from './utils/glState.mjs';
+
+/**
+ * @summary Boot gate: the E2E suite refuses to run silently on a GPU it only *claims* to have.
+ *
+ * Days were spent investigating a suspected vessel/heap-join defect. The actual cause was a
+ * launch flag whose text stayed valid while the runtime moved out from under it — GL resolved to
+ * `none` at every window birth, Chromium's GPU-crash threshold eventually killed the whole browser
+ * mid-suite, and the "GPU-accelerated" benchmark suite had plausibly never rendered one accelerated
+ * frame. It was green the entire time, because a green suite proves the tests passed, not that they
+ * ran under the conditions they claim to measure.
+ *
+ * A source-shaped check cannot catch this class: the config's spelling never rotted, the environment
+ * rotted beneath it. So this gate observes the *effect* — once, at boot, before any benchmark
+ * attributes a number to hardware it may not be using.
+ *
+ * **Placement.** This is a setup project rather than `globalSetup`, following the `chroma-setup`
+ * precedent in `playwright.config.unit.mjs`. `e2e/globalSetup.mjs` runs as a plain node function
+ * outside any launched browser, so it structurally cannot observe the browser's GL state — the
+ * distinction that matters here is exactly the one between reading a config and running under it.
+ *
+ * @see test/playwright/e2e/utils/glState.mjs   three-state reading
+ * @see test/playwright/e2e/utils/gpuIntent.mjs the declaration this gate holds the run to
+ */
+setup('E2E boot: GPU-intent flags resolve to real GL', async ({page}) => {
+    const
+        demandsGl = claimsGpuAcceleration(activeLaunchArgs()),
+        gl        = await readGlState(page),
+        detail    = `state=${gl.state} renderer=${gl.renderer ?? 'n/a'} vendor=${gl.vendor ?? 'n/a'} generic=${gl.generic ?? 'n/a'} reason=${gl.reason ?? 'none'}`;
+
+    // Logged on every outcome, healthy included: a benchmark number is worth what its rendering path
+    // is worth, and the run's own log is where that has to be recoverable afterwards.
+    console.log(`[gl-probe] ${detail}`);
+
+    if (!demandsGl) {
+        console.log('[gl-probe] launch args carry no GPU-intent flag — nothing claimed, nothing demanded.');
+        return
+    }
+
+    // "Could not look" is its own outcome and still stops the run. A probe that waves the suite
+    // through when its own instrument is missing is the same defect wearing this gate's uniform:
+    // it would report the absence of evidence as evidence of health.
+    expect(gl.state, [
+        `E2E boot probe could not determine the GL state (${gl.reason}).`,
+        'This is NOT a pass — the suite claims hardware acceleration and the probe was unable to verify it.',
+        `Observed: ${detail}`,
+        'Fix the probe or the browser surface before trusting any benchmark from this run.'
+    ].join('\n')).not.toBe('unobserved');
+
+    expect(gl.state, [
+        'E2E boot probe: GPU-intent launch flags did NOT resolve to hardware GL.',
+        `Observed: ${detail}`,
+        '',
+        'This is the #15664 class — flag rot. The launch arguments still read correctly; the browser',
+        'no longer honours them, so this suite would render on nothing while reporting GPU numbers.',
+        'Chrome retired --use-gl=desktop via its ANGLE-only allowlist exactly this way.',
+        '',
+        'Check every GPU-intent flag in test/playwright/e2e/utils/gpuIntent.mjs against the current',
+        'Chrome build before assuming a hardware fault. Evidence chain: https://github.com/neomjs/neo/issues/15664'
+    ].join('\n')).toBe('accelerated')
+});

--- a/test/playwright/e2e/globalSetup.mjs
+++ b/test/playwright/e2e/globalSetup.mjs
@@ -1,0 +1,45 @@
+import {execFile}       from 'node:child_process';
+import fs               from 'node:fs';
+import path             from 'node:path';
+import {pathToFileURL}  from 'node:url';
+import {promisify}      from 'node:util';
+
+const execFileAsync = promisify(execFile),
+      REPO_ROOT     = path.resolve(import.meta.dirname, '../../..'),
+      CSS_ROOT      = path.join(REPO_ROOT, 'dist/development/css');
+
+/**
+ * @summary Guarantees a development theme build exists before any browser starts.
+ *
+ * Without `dist/development/css`, the app still boots and the grid header still renders — so the
+ * page looks alive — but the body computes to `height: 0`, row virtualization derives zero visible
+ * rows from it, and every row-dependent assertion fails while the footer cheerfully reports 50,000
+ * records. That reads exactly like a data-layer or engine fault and is neither.
+ *
+ * This is written here rather than reused from the engine for two independent reasons, both
+ * verified rather than assumed:
+ *
+ * 1. `neo.mjs`'s own `buildScripts/util/developmentThemeAssets.mjs` derives its target from
+ *    `import.meta.dirname`, so imported out of `node_modules` it would build into
+ *    `node_modules/neo.mjs/dist/` — never this workspace's `dist/`.
+ * 2. It is not in the published package at the version this repository consumes.
+ *
+ * The same standalone reasoning the unit config records for itself, one layer down.
+ */
+export default async function globalSetup() {
+    if (fs.existsSync(CSS_ROOT) && fs.readdirSync(CSS_ROOT).length > 0) {
+        return
+    }
+
+    // `npm run build-themes` prompts interactively and cannot be scripted; the flags below are the
+    // non-interactive form of the same build.
+    await execFileAsync('node', [
+        './node_modules/neo.mjs/buildScripts/build/themes.mjs', '-f', '-n', '-e', 'dev', '-t', 'all'
+    ], {cwd: REPO_ROOT, maxBuffer: 32 * 1024 * 1024})
+}
+
+// Playwright starts `webServer` before its `globalSetup` hook, so running this module as the first
+// web-server command step closes that ordering gap; the later hook then re-checks and no-ops.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    await globalSetup()
+}

--- a/test/playwright/e2e/grid/ThumbDrag.spec.mjs
+++ b/test/playwright/e2e/grid/ThumbDrag.spec.mjs
@@ -1,0 +1,195 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Desktop (1920x1080): Grid Scroll Thrashing', () => {
+    test.use({ viewport: { width: 1920, height: 1080 } });
+
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/apps/devindex/');
+
+        // 1. Wait for the grid to be visible
+        await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
+
+        // 2. Wait for the streaming to start (Stop button visible)
+        const stopButton = page.locator('.devindex-stop-stream-button');
+        await expect(stopButton).toBeVisible({ timeout: 5000 });
+
+        // 3. Wait for the streaming to finish (Stop button hidden)
+        await expect(stopButton).toBeHidden({ timeout: 60000 });
+
+        // 4. Wait for the UI to settle (buffer time)
+        await page.waitForTimeout(1000);
+    });
+
+    test('High-Velocity Vertical Thumb Drag Stale Render Detection', async ({ page }) => {
+        const result = await page.evaluate(async () => {
+            const bodyWrapper = document.querySelector('.neo-grid-view');
+
+            if (!bodyWrapper) {
+                return { error: 'Grid components not found' };
+            }
+
+            const maxScroll = bodyWrapper.scrollHeight - bodyWrapper.clientHeight;
+            if (maxScroll <= 0) return { skipped: true, reason: 'Not scrollable' };
+
+            let maxDiscrepancy = 0;
+            let discrepancies  = [];
+            let isRunning      = true;
+
+            // Function to parse Y from transform: translate3d(0px, 123px, 0px)
+            const getTranslateY = (el) => {
+                const transform = el.style.transform;
+                if (!transform) return 0;
+                const match = transform.match(/translate3d\([^,]+,\s*([^p]+)px,\s*[^)]+\)/);
+                return match ? parseInt(match[1], 10) : 0;
+            };
+
+            // Monitor loop to capture discrepancies
+            const monitor = setInterval(() => {
+                if (!isRunning) return;
+
+                const currentScrollTop = bodyWrapper.scrollTop;
+                const rows             = Array.from(document.querySelectorAll('.neo-grid-row'));
+                if (rows.length === 0) return;
+
+                const yValues      = rows.map(getTranslateY);
+                const maxRenderedY = Math.max(...yValues);
+                const minRenderedY = Math.min(...yValues);
+
+                // Assuming row height is around 40px, the rendered height is maxY + rowHeight
+                const renderedBottom = maxRenderedY + 40;
+
+                // Discrepancy is when scrollTop goes beyond the rendered bottom
+                // meaning the visible area is below what is currently rendered.
+                if (currentScrollTop > renderedBottom) {
+                    const diff = currentScrollTop - renderedBottom;
+                    if (diff > maxDiscrepancy) {
+                        maxDiscrepancy = diff;
+                    }
+                    discrepancies.push({
+                        time     : performance.now(),
+                        scrollTop: currentScrollTop,
+                        maxRenderedY,
+                        diff
+                    });
+                }
+            }, 10); // Check every 10ms
+
+            // Simulate high-velocity drag
+            const performDrag = async () => {
+                const duration = 1000; // 1 second fast drag
+                const start    = performance.now();
+                const startTop = bodyWrapper.scrollTop;
+                // Drag down by 20000px
+                const targetTop = Math.min(startTop + 20000, maxScroll);
+
+                // Trigger the mousedown to activate thumb dragging pinning logic
+                const rect = bodyWrapper.getBoundingClientRect();
+                bodyWrapper.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: rect.right - 5 }));
+
+                return new Promise(resolve => {
+                    const step = () => {
+                        const elapsed  = performance.now() - start;
+                        const progress = Math.min(elapsed / duration, 1);
+
+                        // We set scrollTop directly to simulate moving the thumb
+                        bodyWrapper.scrollTop = startTop + (targetTop - startTop) * progress;
+
+                        if (progress < 1) {
+                            requestAnimationFrame(step);
+                        } else {
+                            // Trigger the mouse up to deactivate thumb dragging
+                            window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+                            resolve();
+                        }
+                    };
+                    requestAnimationFrame(step);
+                });
+            };
+
+            await performDrag();
+            isRunning = false;
+            clearInterval(monitor);
+
+            // Wait a bit for the final render to catch up
+            await new Promise(r => setTimeout(r, 500));
+
+            // Fetch Performance Metrics from the App worker via the generated Main Thread proxy
+            let metrics = null;
+            if (window.Neo && window.Neo.util && window.Neo.util.Performance) {
+                try {
+                    metrics = await window.Neo.util.Performance.getMetrics();
+                } catch (e) {
+                    console.error('Failed to fetch performance metrics', e);
+                }
+            }
+
+            return {
+                maxDiscrepancy,
+                discrepancyCount: discrepancies.length,
+                discrepancies   : discrepancies.slice(0, 10), // return sample
+                metrics
+            };
+        });
+
+        console.log('Drag Result:', JSON.stringify(result, null, 2));
+        expect(result.error).toBeUndefined();
+        expect(result.metrics).not.toBeNull();
+
+        // If there's a significant discrepancy, it proves the stale render gap exists.
+        // Once we fix it, this gap should be 0 (or very close to it, within the bufferRowRange).
+        // For now, we expect it to be quite large if the bug exists.
+        // But for the sake of the test output right now, let's just log it and assert it is captured.
+
+        // Our goal is to fix it, so eventually maxDiscrepancy should be 0.
+        // If it's failing currently, we can observe the output.
+    });
+
+    test('Horizontal Drag Scroll Moves Cells Optically and Triggers Data Virtualization', async ({ page }) => {
+        const result = await page.evaluate(async () => {
+            const bodyWrapper = document.querySelector('.neo-grid-view');
+            const hScrollbar  = document.querySelector('.neo-grid-horizontal-scrollbar');
+
+            if (!bodyWrapper || !hScrollbar) {
+                return { error: 'Grid components not found' };
+            }
+
+            // Get initial cell boundary
+            const getFirstCellDOMLeft = () => {
+                const centerCell = document.querySelector('.neo-grid-row .neo-grid-cell:not(.neo-locked-start):not(.neo-locked-end)');
+                if (!centerCell) return null;
+                return centerCell.getBoundingClientRect().left;
+            };
+
+            const initialLeft = getFirstCellDOMLeft();
+
+            // 1. Simulate a moderate horizontal scroll for Translation
+            hScrollbar.scrollLeft += 100;
+
+            // Wait for 1 frame to allow CSS variable to apply and be painted
+            await new Promise(r => requestAnimationFrame(r));
+            await new Promise(r => requestAnimationFrame(r));
+
+            // Measure the IMMEDIATE visual shift (CSS translation) before the worker even has a chance to recycle
+            const instantLeft = getFirstCellDOMLeft();
+
+            // 2. Simulate a MASSIVE horizontal scroll to force Data Virtualization (Cell Recycling)
+            hScrollbar.scrollLeft += 2000;
+
+            // Now wait for App Worker Round-trip (Wait for VDOM Patch)
+            await new Promise(r => setTimeout(r, 500));
+
+            return {
+                initialLeft,
+                instantLeft,
+                pixelShift: initialLeft - instantLeft
+            };
+        });
+
+        console.log('Horizontal Scroll Test Result:', JSON.stringify(result, null, 2));
+
+        expect(result.error).toBeUndefined();
+
+        // Assert Visual CSS Translation occurred (Physical pixels shifted left as we scrolled right)
+        expect(result.pixelShift).toBeGreaterThan(0);
+    });
+});

--- a/test/playwright/e2e/grid/ThumbDragDevIndex.spec.mjs
+++ b/test/playwright/e2e/grid/ThumbDragDevIndex.spec.mjs
@@ -1,0 +1,314 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Desktop (1920x1080): DevIndex Grid Row Pinning Validation', () => {
+    test.use({ viewport: { width: 1920, height: 1080 } });
+
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/apps/devindex/');
+        page.on('console', msg => console.log('BROWSER:', msg.text()));
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        // 1. Wait for the grid to be visible
+        await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
+
+        // 2. Wait for the streaming to start (Stop button visible)
+        const stopButton = page.locator('.devindex-stop-stream-button');
+        await expect(stopButton).toBeVisible({ timeout: 5000 });
+
+        // 3. Wait for the streaming to finish (Stop button hidden)
+        await expect(stopButton).toBeHidden({ timeout: 60000 });
+
+        // 4. Wait for the UI to settle (buffer time)
+        await page.waitForTimeout(1000);
+    });
+
+    test('Scroll Telemetry: Visual Blanking and Jitter Detector', async ({ page }) => {
+        await page.mouse.move(960, 540); // Move to center of screen
+
+        const evaluationPromise = page.evaluate(async () => {
+            const wrappers      = document.querySelectorAll('.neo-grid-view');
+            const wrapper       = wrappers.length > 1 ? wrappers[1] : wrappers[0];
+            const content       = wrapper.querySelector('.neo-grid-body');
+            let   telemetry     = [];
+            let   blankFrames   = 0;
+            let   bounces       = 0;
+            let   isRunning     = true;
+            let   lastFrameRows = [];
+
+            const monitor = () => {
+                if (!isRunning) return;
+
+                const wrapperRect = wrapper.getBoundingClientRect();
+                const rows        = Array.from(document.querySelectorAll('.neo-grid-row'));
+
+                let isBlank    = false;
+                let rowsTop    = 0;
+                let rowsBottom = 0;
+
+                if (rows.length === 0) {
+                    isBlank = true;
+                } else {
+                    const rowRects = rows.map(r => r.getBoundingClientRect());
+                    rowsTop = Math.min(...rowRects.map(r => r.top));
+                    rowsBottom = Math.max(...rowRects.map(r => r.bottom));
+
+                    // Check if the entire block of rows is physically outside the visible wrapper bounds
+                    if (rowsBottom < wrapperRect.top || rowsTop > wrapperRect.bottom) {
+                        isBlank = true;
+                    }
+
+                    // Detect visual bouncing/jitter (rows moving down while we scroll down)
+                    const trackingRow = rows.find(r =>
+                        lastFrameRows.some(lastR => lastR.id === r.id && lastR.dataset.recordId === r.dataset.recordId)
+                    );
+
+                    if (trackingRow) {
+                        const row        = trackingRow.getBoundingClientRect();
+                        const currentTop = row.top;
+
+                        if (trackingRow.id && window.__TELEMETRY && window.__TELEMETRY.length > 1) {
+                            const lastTopObj = Object.values(window.__TELEMETRY[window.__TELEMETRY.length - 2] || {}).find(r => r.id === trackingRow.id);
+                            if (lastTopObj) {
+                                const lastTop = lastTopObj.top;
+                                if (currentTop > lastTop + 2) {
+                                    bounces++;
+                                    if (window.__PROFILE7) {
+                                        const myBody = trackingRow.closest('.neo-grid-body');
+                                        window.__DEBUG_BOUNCES = window.__DEBUG_BOUNCES || [];
+                                        window.__DEBUG_BOUNCES.push(`Row ${trackingRow.id}: currentTop=${currentTop}, lastTop=${lastTop}, diff=${currentTop - lastTop}, wrapperScrollTop=${wrapper.scrollTop}, bodyId=${myBody ? myBody.id : '?'}, offset=${myBody ? myBody.style.getPropertyValue('--grid-row-pin-offset') : '?'}, transform=${trackingRow.style.transform}`);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    lastFrameRows = rows.map(r => ({
+                        id     : r.id,
+                        dataset: { recordId: r.dataset.recordId },
+                        top    : r.getBoundingClientRect().top
+                    }));
+                }
+
+                if (isBlank) {
+                    blankFrames++;
+                    if (window.__PROFILE7) {
+                        console.log(`[isBlank PROF 7] wrapper: ${wrapperRect.top}->${wrapperRect.bottom}, rows: ${rowsTop}->${rowsBottom}, scrollTop: ${wrapper.scrollTop}, offset: ${content.style.getPropertyValue('--grid-row-pin-offset')}`);
+                    }
+                }
+
+                if (window.__RESET_METRICS) {
+                    blankFrames = 0;
+                    bounces = 0;
+                    window.__RESET_METRICS = false;
+                }
+
+                telemetry.push({
+                    time     : performance.now(),
+                    scrollTop: wrapper.scrollTop,
+                    transform: content.style.getPropertyValue('--grid-row-pin-offset'),
+                    isBlank,
+                    bounces
+                });
+
+                requestAnimationFrame(monitor);
+            };
+
+            requestAnimationFrame(monitor);
+
+            // Let it run while playwright scrolls
+            await new Promise(r => setTimeout(r, 16000));
+            isRunning = false;
+
+            return { telemetry, blankFrames, bounces };
+        });
+
+        console.log('--- Profile 1: Slow Wheel (2-3 rows) ---');
+        for(let i=0; i<10; i++) {
+            await page.mouse.wheel(0, 100);
+            await page.waitForTimeout(100);
+        }
+
+        await page.waitForTimeout(500);
+
+        console.log('--- Profile 2: Up/Down Ping-Pong ---');
+        for(let i=0; i<5; i++) {
+            await page.mouse.wheel(0, 500);
+            await page.waitForTimeout(100);
+            await page.mouse.wheel(0, -500);
+            await page.waitForTimeout(100);
+        }
+
+        await page.waitForTimeout(500);
+
+        console.log('--- Profile 3: Accelerated Wheel ---');
+        let delta = 100;
+        for(let i=0; i<8; i++) {
+            await page.mouse.wheel(0, delta);
+            delta *= 1.5;
+            await page.waitForTimeout(100);
+        }
+
+        await page.waitForTimeout(500);
+
+        // --- Synthetic Drag Profiles ---
+        // Let them run without pinning first so that the browser handles them natively.
+
+
+        console.log('--- Profile 4: Synthetic Steady Slow Drag ---');
+        for(let i=0; i<10; i++) {
+            await page.evaluate(() => {
+                const wrappers = document.querySelectorAll('.neo-grid-view');
+                const w        = wrappers.length > 1 ? wrappers[1] : wrappers[0];
+                w.scrollTop += 100;
+            });
+            await page.waitForTimeout(50);
+        }
+
+        await page.waitForTimeout(500);
+
+        console.log('--- Profile 5: Synthetic Drag Ping-Pong ---');
+        for(let i=0; i<5; i++) {
+            await page.evaluate(() => {
+                const wrappers = document.querySelectorAll('.neo-grid-view');
+                const w        = wrappers.length > 1 ? wrappers[1] : wrappers[0];
+                w.scrollTop += 500;
+            });
+            await page.waitForTimeout(100);
+            await page.evaluate(() => {
+                const wrappers = document.querySelectorAll('.neo-grid-view');
+                const w        = wrappers.length > 1 ? wrappers[1] : wrappers[0];
+                w.scrollTop -= 500;
+            });
+            await page.waitForTimeout(100);
+        }
+
+        await page.waitForTimeout(500);
+
+        console.log('--- Profile 6: Synthetic Massive Snap Drag ---');
+        await page.evaluate(() => {
+            const wrappers = document.querySelectorAll('.neo-grid-view');
+            const w        = wrappers.length > 1 ? wrappers[1] : wrappers[0];
+            w.scrollTop += 50000;
+        });
+        await page.waitForTimeout(500);
+
+        console.log('--- Profile 7: Authentic High-Frequency Native Drag (50px/sec thumb equivalent) ---');
+        const wrappers    = page.locator('.neo-grid-view');
+        const wrapperNode = await wrappers.count() > 1 ? wrappers.nth(1) : wrappers.first();
+        const box         = await wrapperNode.boundingBox();
+
+        // Emulate the human pointer exactly at the vertical scrollbar thumb location.
+        // Assuming thumb starts near the top of the wrapper.
+        const startX = box.x + box.width - 5;
+        const startY = box.y + 20;
+
+        // 1. Position mouse on the thumb
+        await page.mouse.move(startX, startY);
+
+        // 2. Start telemetry and press mouse down
+        await page.evaluate(() => {
+            window.__PROFILE7 = true;
+            window.__RESET_METRICS = true;
+
+            // Create a small promise to allow Playwright's async test blocks to advance
+            return Promise.resolve();
+        });
+        await page.mouse.down();
+
+        // 3. Perform a 2-second continuous smooth drag down by 100 pixels (50px/sec native thumb movement)
+        // using 'steps: 120' to force a 60fps event cadence from the browser.
+        await page.mouse.move(startX, startY + 100, { steps: 120 });
+
+        // 4. Release mouse and finish sequence
+        await page.mouse.up();
+        await page.waitForTimeout(500);
+
+        await page.evaluate(() => {
+            window.__PROFILE7 = false;
+        });
+
+        const { telemetry, blankFrames, bounces, debugBounces } = await evaluationPromise;
+
+        console.log(`Total Frames Measured: ${telemetry.length}`);
+        console.log(`Total Blank Frames (White Flash): ${blankFrames}`);
+        console.log(`Total Jitter Bounces Detected: ${bounces}`);
+        if (debugBounces && debugBounces.length > 0) {
+            console.log('--- DEBUG BOUNCES ---');
+            debugBounces.forEach(b => console.log(b));
+            console.log('---------------------');
+        }
+
+        // Assertions
+        expect(blankFrames).toBe(0);
+        expect(bounces).toBe(0);
+    });
+
+    test('Horizontal Drag Scroll Moves Cells Optically and Triggers Data Virtualization', async ({ page }) => {
+        const result = await page.evaluate(async () => {
+            const wrappers    = document.querySelectorAll('.neo-grid-view');
+            const bodyWrapper = wrappers.length > 1 ? wrappers[1] : wrappers[0];
+            const hScrollbar  = document.querySelector('.neo-grid-horizontal-scrollbar');
+
+            if (!bodyWrapper || !hScrollbar) {
+                return { error: 'Grid components not found' };
+            }
+
+            // Get initial cell boundary
+            const getFirstCellDOMLeft = () => {
+                const centerCell = document.querySelector('.neo-grid-row .neo-grid-cell:not(.neo-locked-start):not(.neo-locked-end)');
+                if (!centerCell) return null;
+                return centerCell.getBoundingClientRect().left;
+            };
+
+            const initialLeft = getFirstCellDOMLeft();
+
+            // Get locked cells' boundaries
+            const getLockedCellLefts = () => {
+                const startCell = document.querySelector('.neo-grid-row .neo-grid-cell.neo-locked-start');
+                const endCell   = document.querySelector('.neo-grid-row .neo-grid-cell.neo-locked-end');
+                return {
+                    startLeft: startCell ? startCell.getBoundingClientRect().left : null,
+                    endLeft  : endCell ? endCell.getBoundingClientRect().left : null
+                };
+            };
+
+            const initialLockedLefts = getLockedCellLefts();
+
+            // 1. Simulate a moderate horizontal scroll for Translation
+            hScrollbar.scrollLeft += 100;
+
+            // Wait for 1 frame to allow CSS variable to apply and be painted
+            await new Promise(r => requestAnimationFrame(r));
+            await new Promise(r => requestAnimationFrame(r));
+
+            // Measure the IMMEDIATE visual shift (CSS translation) before the worker even has a chance to recycle
+            const instantLeft        = getFirstCellDOMLeft();
+            const instantLockedLefts = getLockedCellLefts();
+
+            // 2. Simulate a MASSIVE horizontal scroll to force Data Virtualization (Cell Recycling)
+            hScrollbar.scrollLeft += 2000;
+
+            // Now wait for App Worker Round-trip (Wait for VDOM Patch)
+            await new Promise(r => setTimeout(r, 500));
+
+            return {
+                initialLeft,
+                instantLeft,
+                pixelShift       : initialLeft - instantLeft,
+                lockedStartStable: initialLockedLefts.startLeft === instantLockedLefts.startLeft,
+                lockedEndStable  : initialLockedLefts.endLeft === instantLockedLefts.endLeft
+            };
+        });
+
+        console.log('Horizontal Scroll Test Result:', JSON.stringify(result, null, 2));
+
+        expect(result.error).toBeUndefined();
+
+        // Assert Visual CSS Translation occurred (Physical pixels shifted left as we scrolled right)
+        expect(result.pixelShift).toBeGreaterThan(0);
+
+        // Assert locked columns remained visually stationary
+        expect(result.lockedStartStable).toBe(true);
+        expect(result.lockedEndStable).toBe(true);
+    });
+});

--- a/test/playwright/e2e/grid/ThumbDragPause.spec.mjs
+++ b/test/playwright/e2e/grid/ThumbDragPause.spec.mjs
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Grid Scroll Pinning Thumb Drag Pause', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/apps/devindex/index.html');
+        // Wait for the grid rows to stabilize
+        await page.waitForSelector('.neo-grid-row', { state: 'attached' });
+        await page.waitForTimeout(1000);
+    });
+
+    test('Pausing during thumb drag keeps pinning active', async ({ page }) => {
+        const wrapperNode = await page.locator('.neo-grid-view');
+        const box         = await wrapperNode.boundingBox();
+
+        const startX = box.x + box.width - 5;
+        const startY = box.y + 20;
+
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+
+        // Emulate a pause longer than the removed timeout window.
+        await page.waitForTimeout(2500);
+
+        // Emulate a massive snap drag after the pause
+        // Pinning must survive the pause, so this should not blank visual rows.
+        await page.evaluate(() => {
+            window.__BLANK = false;
+            const wrapper = document.querySelector('.neo-grid-view');
+            wrapper.addEventListener('scroll', () => {
+                const rows        = Array.from(wrapper.querySelectorAll('.neo-grid-row'));
+                const wrapperRect = wrapper.getBoundingClientRect();
+                if (rows.length === 0) {
+                    window.__BLANK = true;
+                    return
+                }
+                const rowsTop     = Math.min(...rows.map(r => r.getBoundingClientRect().top));
+                const rowsBottom  = Math.max(...rows.map(r => r.getBoundingClientRect().bottom));
+                if (rowsBottom < wrapperRect.top || rowsTop > wrapperRect.bottom) {
+                    window.__BLANK = true;
+                }
+            });
+        });
+
+        await page.mouse.move(startX, startY + 50000);
+        await page.mouse.move(startX, startY + 100000);
+
+        const isBlank = await page.evaluate(() => window.__BLANK);
+        await page.mouse.up();
+        expect(isBlank).toBe(false);
+    });
+});

--- a/test/playwright/e2e/utils/browser-test-helpers.mjs
+++ b/test/playwright/e2e/utils/browser-test-helpers.mjs
@@ -1,0 +1,135 @@
+export const measurePerformanceInBrowser = (testName, action, condition, passThrough, { timeout = 30000, resolveOnTimeout = false } = {}) => {
+    return new Promise((resolve, reject) => {
+        const observer = new MutationObserver(() => {
+            try {
+                if (condition(passThrough)) {
+                    const endTime = performance.now();
+                    observer.disconnect();
+                    clearTimeout(timeoutId);
+                    resolve(endTime - startTime);
+                }
+            } catch (e) {
+                observer.disconnect();
+                clearTimeout(timeoutId);
+                console.error(`Condition error in ${testName}:`, e);
+                reject(e);
+            }
+        });
+
+        observer.observe(document.body, {attributes: true, childList: true, subtree: true});
+
+        const timeoutId = setTimeout(() => {
+            observer.disconnect();
+            if (resolveOnTimeout) {
+                resolve(Infinity);
+            } else {
+                reject(new Error(`Benchmark timed out for "${testName}".`));
+            }
+        }, timeout);
+
+        const startTime = performance.now();
+        try {
+            action(passThrough);
+        } catch (e) {
+            console.error(`Action error in ${testName}:`, e);
+            observer.disconnect();
+            clearTimeout(timeoutId);
+            reject(e);
+            return;
+        }
+
+        try {
+            if (condition(passThrough)) {
+                const endTime = performance.now();
+                observer.disconnect();
+                clearTimeout(timeoutId);
+                resolve(endTime - startTime);
+            }
+        } catch (e) {
+            observer.disconnect();
+            clearTimeout(timeoutId);
+            console.error(`Initial condition check error in ${testName}:`, e);
+            reject(e);
+        }
+    });
+};
+
+export const measureUiUpdatePerformanceInBrowser = (testName, condition) => {
+    return new Promise((resolve, reject) => {
+        const observer = new MutationObserver(() => {
+            try {
+                if (condition()) {
+                    const endTime = performance.now();
+                    observer.disconnect();
+                    clearTimeout(timeoutId);
+                    resolve(endTime - startTime);
+                }
+            } catch (e) {
+                observer.disconnect();
+                clearTimeout(timeoutId);
+                console.error(`Condition error in ${testName}:`, e);
+                reject(e);
+            }
+        });
+
+        observer.observe(document.body, {attributes: true, childList: true, subtree: true});
+
+        const timeoutId = setTimeout(() => {
+            observer.disconnect();
+            reject(new Error(`UI update benchmark timed out for "${testName}".`));
+        }, 30000);
+
+        const startTime = performance.now(); // Measurement starts here
+        // The action (store.add) is assumed to have just happened
+    });
+};
+
+/**
+ * Measures UI jank by collecting frame timings over a given duration.
+ * This function will be injected into the browser context.
+ * @param {number} duration - The duration in milliseconds to measure jank.
+ * @returns {Promise<{averageFps: number, frameCount: number, longFrameCount: number, totalTime: number}>}
+ */
+export const measureJankInBrowser = (duration) => {
+    return new Promise(resolve => {
+        const frameTimes = [];
+        let longFrameCount = 0;
+        let startTime;
+
+        function frame(time) {
+            if (startTime === undefined) {
+                startTime = time;
+            }
+
+            const elapsed = time - startTime;
+            frameTimes.push(time);
+
+            if (elapsed < duration) {
+                requestAnimationFrame(frame);
+            } else {
+                // Start from the second frame to calculate deltas
+                for (let i = 1; i < frameTimes.length; i++) {
+                    const delta = frameTimes[i] - frameTimes[i - 1];
+                    // A long frame is arbitrarily defined as > 50ms (~20 FPS threshold)
+                    // This indicates significant main-thread blocking.
+                    if (delta > 50) {
+                        longFrameCount++;
+                    }
+                }
+
+                const totalTime = frameTimes[frameTimes.length - 1] - frameTimes[0];
+                // We have frameTimes.length - 1 frame intervals
+                const averageFps = totalTime > 0 ? (frameTimes.length - 1) / (totalTime / 1000) : 0;
+
+                resolve({
+                    averageFps: Math.round(averageFps),
+                    frameCount: frameTimes.length,
+                    longFrameCount,
+                    totalTime: Math.round(totalTime)
+                });
+            }
+        }
+
+        requestAnimationFrame(frame);
+    });
+};

--- a/test/playwright/e2e/utils/glState.mjs
+++ b/test/playwright/e2e/utils/glState.mjs
@@ -1,0 +1,86 @@
+/**
+ * @summary Reads the live GL state of a launched browser, as three states rather than two.
+ *
+ * This module exists because of a configuration whose *text* never rotted — `--use-gl=desktop` stayed
+ * spelled correctly while Chrome's ANGLE-only allowlist quietly stopped accepting it, so GL resolved
+ * to `none` from the day the flag landed. No source-shaped instrument can see that: the config reads
+ * fine, the lint passes, the suite is green. Only the *effect* differs, so only an effect probe finds it.
+ *
+ * **Three states, not two — this is the point of the module.** A probe that answers
+ * healthy-or-degraded is itself a Face-C artifact: when `WEBGL_debug_renderer_info` is unavailable
+ * it would report the absence of evidence as evidence of health, which is the same shape as the bug
+ * it guards. `unobserved` exists so "could not look" can never be spoken as "looked and it was fine".
+ *
+ * @see test/playwright/e2e/gl.setup.mjs  the boot gate that acts on this reading
+ * @see https://github.com/neomjs/neo/issues/15664  the incident
+ * @see https://github.com/orgs/neomjs/discussions/15812  the artifact-that-cannot-fail class
+ */
+
+/**
+ * @summary Substrings that identify a software rasterizer in an unmasked renderer string.
+ *
+ * **Deliberately a deny-list, and deliberately incomplete.** An allow-list of hardware renderers
+ * would need every GPU on every platform and would fail closed on the next one shipped — a guard
+ * that breaks on new hardware gets switched off. This list is the *secondary* signal; the primary
+ * one is structural and needs no string matching at all: under `--use-gl=desktop` paired with
+ * `--disable-software-rasterizer` a WebGL context cannot be created at all, so `context: false` is
+ * the unambiguous tell. Treat additions here as refinements, never as the mechanism.
+ * @type {String[]}
+ */
+export const SOFTWARE_RENDERER_MARKERS = ['swiftshader', 'llvmpipe', 'software', 'microsoft basic render'];
+
+/**
+ * @summary Observes the browser's actual GL capability from inside the launched page.
+ *
+ * Runs in page context: creates a throwaway canvas, requests a WebGL context, and asks
+ * `WEBGL_debug_renderer_info` for the unmasked renderer. The generic `gl.getParameter(gl.RENDERER)`
+ * is captured too but is not decisive — Chrome answers `'WebKit WebGL'` regardless of what is
+ * underneath, verified on a healthy macOS seat, so it cannot separate hardware from software.
+ *
+ * @param {Object}   page                A Playwright page on any loaded document.
+ * @returns {Promise<{state: String, renderer: String|null, vendor: String|null, generic: String|null, reason: String|null}>}
+ *          `state` is one of:
+ *          - `'accelerated'` — a context exists and its unmasked renderer names no software rasterizer.
+ *          - `'degraded'`    — no WebGL context at all, or the renderer names a software rasterizer.
+ *          - `'unobserved'`  — a context exists but the renderer could not be identified, or the
+ *                              evaluation itself failed. **Never** collapse this into `'accelerated'`.
+ */
+export async function readGlState(page) {
+    let raw;
+
+    try {
+        raw = await page.evaluate(() => {
+            const
+                canvas = document.createElement('canvas'),
+                gl     = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+
+            if (!gl) return {context: false};
+
+            const ext = gl.getExtension('WEBGL_debug_renderer_info');
+
+            return {
+                context : true,
+                renderer: ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : null,
+                vendor  : ext ? gl.getParameter(ext.UNMASKED_VENDOR_WEBGL)   : null,
+                generic : gl.getParameter(gl.RENDERER)
+            }
+        })
+    } catch (error) {
+        // The probe failing is not the browser being healthy. Say so.
+        return {state: 'unobserved', renderer: null, vendor: null, generic: null, reason: `probe-evaluation-failed: ${error?.message ?? 'unknown'}`}
+    }
+
+    if (!raw.context) {
+        return {state: 'degraded', renderer: null, vendor: null, generic: null, reason: 'no-webgl-context'}
+    }
+
+    if (!raw.renderer) {
+        return {state: 'unobserved', renderer: null, vendor: raw.vendor, generic: raw.generic, reason: 'webgl-debug-renderer-info-unavailable'}
+    }
+
+    const software = SOFTWARE_RENDERER_MARKERS.find(marker => raw.renderer.toLowerCase().includes(marker));
+
+    return software
+        ? {state: 'degraded', renderer: raw.renderer, vendor: raw.vendor, generic: raw.generic, reason: `software-renderer: ${software}`}
+        : {state: 'accelerated', renderer: raw.renderer, vendor: raw.vendor, generic: raw.generic, reason: null}
+}

--- a/test/playwright/e2e/utils/gpuIntent.mjs
+++ b/test/playwright/e2e/utils/gpuIntent.mjs
@@ -1,0 +1,151 @@
+/**
+ * @summary The E2E browser's launch arguments, split so the GPU intent is machine-readable.
+ *
+ * This module is the single declaration. `playwright.config.e2e.mjs` spreads it into the project's
+ * `launchOptions`, and the boot probe reads it to decide whether hardware GL is something this run
+ * is *entitled to demand*. A second hand-maintained copy in the probe would drift, and drift between
+ * two statements of the same fact is how a dead GL flag stayed invisible for five months.
+ *
+ * **Why the split matters.** The probe must not demand GL unconditionally. If a future config drops
+ * every accelerator flag — a legitimate choice for a headless CI lane — a probe that still failed on
+ * software rendering would be a guard nobody could satisfy, and guards nobody can satisfy get
+ * disabled. Reading the intent from the declaration keeps the demand proportional to the claim.
+ *
+ * **NEVER add `--use-gl=desktop` or `--disable-software-rasterizer` to ANY list in this module.**
+ * The prohibition is module-wide on purpose: `--use-gl=desktop` reads like a GPU selector and a
+ * maintainer's hand goes to `GPU_INTENT_ARGS`, so a ban scoped to one list guards the wrong surface.
+ * Modern Chrome's GL allowlist is ANGLE-only (metal/opengl/swiftshader), so `desktop` resolves to
+ * gl=none — the GPU process then dies at EVERY window birth, and with the software fallback disabled
+ * Chromium's crash threshold kills the whole browser mid-test in headed mode (the second popup birth
+ * crossed it deterministically: "GPU process isn't usable. Goodbye." → SIGTRAP, all SharedWorkers
+ * gone). Default ANGLE (Metal on macOS) IS the hardware path — measured on this seat, headed and
+ * headless: "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Max)". This is the source authority for
+ * that removal; `gl.setup.mjs` enforces it at runtime, but the two together are cheaper than either.
+ *
+ * @see test/playwright/e2e/gl.setup.mjs  the boot probe that consumes GPU_INTENT_ARGS
+ * @see https://github.com/neomjs/neo/issues/15664  the five-month-silent dead-flag incident
+ */
+
+/**
+ * @summary Flags whose only purpose is to obtain hardware-accelerated rendering.
+ *
+ * Presence of any of these is the run asserting *"this suite renders on the GPU"* — which is exactly
+ * the claim the boot probe verifies against the live browser. Flags that merely tune an already
+ * accelerated pipeline (`--disable-frame-rate-limit`, `--force-gpu-mem-available-mb`) are NOT here:
+ * they do not by themselves claim acceleration, so they must not arm the demand.
+ * @type {String[]}
+ */
+export const GPU_INTENT_ARGS = [
+    '--ignore-gpu-blocklist',
+    '--enable-gpu-rasterization',
+    '--enable-zero-copy',
+    '--enable-accelerated-2d-canvas'
+];
+
+/**
+ * @summary Shared browser isolation, memory, throttling, and sandbox arguments.
+ *
+ * The explicit engine profile uses this list unchanged. The presenting profile removes the
+ * frame-rate override which suppresses compositor frames on headed Retina hosts.
+ * @type {String[]}
+ */
+export const BASE_LAUNCH_ARGS = [
+    '--disable-frame-rate-limit',
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '--js-flags=--max_old_space_size=8192',
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-renderer-backgrounding',
+    '--disable-dev-shm-usage',
+    '--disable-ipc-flooding-protection',
+    '--force-gpu-mem-available-mb=4096',
+    '--disable-features=IsolateOrigins,site-per-process'
+];
+
+/**
+ * @summary The explicit engine/benchmark launch profile.
+ *
+ * This profile retains the GPU-intent flags and uncapped frame scheduling used by engine and
+ * benchmark investigations. It is deliberately not the default for headed UI work because
+ * `--disable-frame-rate-limit` can leave the application semantically live behind empty windows.
+ * @type {String[]}
+ */
+export const ENGINE_LAUNCH_ARGS = [...GPU_INTENT_ARGS, ...BASE_LAUNCH_ARGS];
+
+/**
+ * @summary The default presenting launch profile: headed work needs frames on glass.
+ *
+ * `--disable-frame-rate-limit` suppresses headed compositing entirely on retina hosts —
+ * `page.screenshot` starves for the full test timeout and every screen-capture grain records
+ * black while worker-truth stays green — so the ordinary headed profile drops it. GPU-intent
+ * flags are benchmark claims a presenting run does not make. The backgrounding-disable trio
+ * STAYS: a newborn tear-out vessel is an occluded window whose renderer must keep running long
+ * enough to join the shared heap, or vessels are never born.
+ * @type {String[]}
+ */
+export const PRESENTING_LAUNCH_ARGS = BASE_LAUNCH_ARGS.filter(arg => arg !== '--disable-frame-rate-limit');
+
+/**
+ * @summary Whether the exact public sentinel selects film pacing and recording behavior.
+ * @returns {Boolean}
+ */
+export function isFilmTake() {
+    return process.env.NEO_FILM_TAKE === '1'
+}
+
+/**
+ * @summary Whether the exact public sentinel selects the non-presenting engine profile.
+ * @returns {Boolean}
+ */
+export function isEngineProfile() {
+    return process.env.NEO_E2E_ENGINE_PROFILE === '1'
+}
+
+/**
+ * @summary The launch list the current run mode actually uses.
+ *
+ * Single selection point for config projects AND the boot probe: the probe must demand GL
+ * proportional to the args the suite really launches with — reading intent from one list while
+ * launching another is the drift class this module exists to prevent. Film capture remains a
+ * spec-level pacing/recording mode; it no longer selects whether headed windows present pixels.
+ *
+ * Film capture and the engine profile are mutually exclusive. Allowing both would start video
+ * capture under the one profile already known not to present compositor frames, turning a clear
+ * configuration error into a late screenshot timeout or black recording.
+ * @returns {String[]}
+ */
+export function activeLaunchArgs() {
+    if (isFilmTake() && isEngineProfile()) {
+        throw new Error(
+            'NEO_FILM_TAKE=1 cannot be combined with NEO_E2E_ENGINE_PROFILE=1: ' +
+            'film capture requires the presenting browser profile.'
+        )
+    }
+
+    return isEngineProfile() ? ENGINE_LAUNCH_ARGS : PRESENTING_LAUNCH_ARGS
+}
+
+/**
+ * @summary Whether a given argument list claims hardware acceleration.
+ * @param {String[]} [args=PRESENTING_LAUNCH_ARGS]
+ * @returns {Boolean}
+ */
+export function claimsGpuAcceleration(args = PRESENTING_LAUNCH_ARGS) {
+    return args.some(arg => GPU_INTENT_ARGS.includes(arg))
+}
+
+/**
+ * @summary Whether the active E2E browser contract requires a separate live-GL effect probe.
+ *
+ * A presenting run claims no GPU acceleration, so launching a second branded-Chrome owner merely
+ * to report "nothing demanded" adds a same-bundle application-registration boundary without
+ * protecting a claim. Engine runs retain the probe because their GPU-intent flags make live GL a
+ * measured prerequisite rather than an optional diagnostic.
+ *
+ * @param {String[]} [args=activeLaunchArgs()]
+ * @returns {Boolean}
+ */
+export function requiresGlProbe(args = activeLaunchArgs()) {
+    return claimsGpuAcceleration(args)
+}

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -9,11 +9,8 @@ import {activeLaunchArgs, requiresGlProbe}  from './e2e/utils/gpuIntent.mjs';
  *
  * The header runs an OffscreenCanvas animation, and the `Activity (17y)` column runs one **per
  * mounted cell** — twenty to forty concurrent animations at a normal viewport, on top of a 50,000
- * record grid. Every spec here measures that: two are wall-clock benchmarks, the other three drive
- * real pointer gestures against it. Under the presenting profile they would run with no GPU-intent
- * flags and with the frame-rate limiter on, so a jank measurement would report the vsync cap and a
- * canvas-heavy scroll would be rasterized without acceleration. The numbers would look perfectly
- * healthy and mean nothing.
+ * record grid. That workload is present in every spec here regardless of what the spec asserts, so
+ * the GPU-intent flags apply to all of them and `e2e/gl.setup.mjs` gates on their taking effect.
  *
  * The engine repository's opposite default is equally correct for it: most of its e2e suite is
  * functional, and `--disable-frame-rate-limit` suppresses headed compositing on retina hosts, which
@@ -21,6 +18,12 @@ import {activeLaunchArgs, requiresGlProbe}  from './e2e/utils/gpuIntent.mjs';
  *
  * Set `NEO_E2E_ENGINE_PROFILE=0` to opt back into presenting — needed only if a spec here ever
  * starts capturing frames, which none currently does.
+ *
+ * **What evidences which flag class, because the two are easy to conflate.** The GPU-intent flags are
+ * proven by the GL gate reporting `state=accelerated` on a real renderer — never by a timing. Frame
+ * scheduling is proven by `GridProfile`'s own CPU breakdown, which reports roughly six times the
+ * Scripting total uncapped (Mobile 815 → 4902 ms, Laptop 913 → 5310 ms). That is more work SAMPLED
+ * in the same window, not slower work, and it is precisely why the two axes are split below.
  */
 process.env.NEO_E2E_ENGINE_PROFILE ??= '1';
 
@@ -52,18 +55,53 @@ const __filename   = fileURLToPath(import.meta.url),
  * collection workflow fetches the index itself. So under CI there is no data, the body renders no
  * rows, and all eleven cases fail for a reason that has nothing to do with the code.
  *
- * Two of them are also wall-clock benchmarks. `.github/workflows/ci.yml` already records the same
+ * `GridProfile` also emits wall-clock CPU totals. `.github/workflows/ci.yml` already records the same
  * hazard one job up, excluding the profiling specs because a shared runner can double their budget —
  * "a regression report for something that did not regress". That reasoning applies here harder, not
  * less. The engine repository reaches the same conclusion by the same route: nothing in its
  * workflows runs its e2e suite either.
  *
  * This is a local / pre-merge suite. Run it before touching the grid, the store or the scroll path.
+ *
+ * ## Provenance of `e2e/utils/gpuIntent.mjs`, `e2e/utils/glState.mjs`, `e2e/gl.setup.mjs`
+ *
+ * Byte-identical copies of the engine's, taken deliberately as a **temporary bridge**, not adopted as
+ * a fork. They are generic browser-policy code with no DevIndex knowledge in them, and duplicating
+ * generic policy is how two repositories quietly diverge on what "accelerated" means.
+ *
+ * **Retirement trigger:** the moment `neo.mjs` publishes a test-support surface that exports them —
+ * or any consumer beyond this repository needs the same trio. Whoever hits either should delete these
+ * three files and import instead. Until then the duplication is the cheaper of two bad options,
+ * because the alternative is this suite having no acceleration gate at all.
  */
-const browserProject = {
-    name: 'chromium',
-    use : {channel: 'chrome', launchOptions: {args: launchArgs}}
-};
+/**
+ * Acceleration and frame scheduling are two axes, and only one of them is demanded.
+ *
+ * The operator's requirement is full GPU support — that is the GPU-intent flags, and it applies to
+ * everything here, because the header canvas and the per-mounted-cell `Activity` canvases are
+ * present in every spec regardless of what the spec asserts.
+ *
+ * `--disable-frame-rate-limit` is a different claim. Uncapping the compositor is right for a
+ * profiler that wants to see the engine's real work rate, and wrong for a gesture spec that asserts
+ * what a user would observe: a drag measured on an uncapped compositor is no longer representative
+ * of the capped browser everyone actually runs. So the functional specs stay capped and only the
+ * measurement project uncaps.
+ *
+ * Both share the same GPU-intent flags, so the GL gate below covers both.
+ */
+const CAPPED_ARGS = launchArgs.filter(arg => arg !== '--disable-frame-rate-limit'),
+
+      functionalProject = {
+          name      : 'chromium',
+          testMatch : /e2e[\\/]grid[\\/].*\.spec\.mjs$/,
+          use       : {channel: 'chrome', launchOptions: {args: CAPPED_ARGS}}
+      },
+
+      benchmarkProject = {
+          name      : 'benchmark',
+          testMatch : /e2e[\\/]benchmarks[\\/].*\.spec\.mjs$/,
+          use       : {channel: 'chrome', launchOptions: {args: launchArgs}}
+      };
 
 export default defineConfig({
     testDir      : path.join(__dirname, 'e2e'),
@@ -86,7 +124,6 @@ export default defineConfig({
         // `playwright install`, so the bundled chromium is absent on a fresh checkout and the run
         // fails at launch with a missing-executable error that looks like a config fault.
         channel      : 'chrome',
-        launchOptions: {args: launchArgs},
         trace        : 'on-first-retry',
         viewport     : {width: 1920, height: 1080}
     },
@@ -116,9 +153,8 @@ export default defineConfig({
         name     : 'gl-probe',
         testMatch: /gl\.setup\.mjs$/,
         use      : {channel: 'chrome', launchOptions: {args: launchArgs}}
-    }, {
-        ...browserProject,
-        testIgnore  : /gl\.setup\.mjs$/,
-        dependencies: ['gl-probe']
-    }] : [{...browserProject, testIgnore: /gl\.setup\.mjs$/}]
+    },
+        {...functionalProject, dependencies: ['gl-probe']},
+        {...benchmarkProject,  dependencies: ['gl-probe']}
+    ] : [functionalProject, benchmarkProject]
 });

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -1,11 +1,35 @@
-import {defineConfig}  from '@playwright/test';
-import path            from 'path';
-import {fileURLToPath} from 'url';
+import {defineConfig}                       from '@playwright/test';
+import path                                 from 'path';
+import {fileURLToPath}                      from 'url';
+import {activeLaunchArgs, requiresGlProbe}  from './e2e/utils/gpuIntent.mjs';
 
-const __filename = fileURLToPath(import.meta.url),
-      __dirname  = path.dirname(__filename),
-      REPO_ROOT  = path.resolve(__dirname, '../..'),
-      PORT       = Number(process.env.DEVINDEX_E2E_PORT || 8090);
+/**
+ * This suite defaults to the ENGINE profile, where the engine repository defaults to presenting.
+ * The difference is not preference, it is what this app is:
+ *
+ * The header runs an OffscreenCanvas animation, and the `Activity (17y)` column runs one **per
+ * mounted cell** — twenty to forty concurrent animations at a normal viewport, on top of a 50,000
+ * record grid. Every spec here measures that: two are wall-clock benchmarks, the other three drive
+ * real pointer gestures against it. Under the presenting profile they would run with no GPU-intent
+ * flags and with the frame-rate limiter on, so a jank measurement would report the vsync cap and a
+ * canvas-heavy scroll would be rasterized without acceleration. The numbers would look perfectly
+ * healthy and mean nothing.
+ *
+ * The engine repository's opposite default is equally correct for it: most of its e2e suite is
+ * functional, and `--disable-frame-rate-limit` suppresses headed compositing on retina hosts, which
+ * starves `page.screenshot`. Nothing here captures screenshots.
+ *
+ * Set `NEO_E2E_ENGINE_PROFILE=0` to opt back into presenting — needed only if a spec here ever
+ * starts capturing frames, which none currently does.
+ */
+process.env.NEO_E2E_ENGINE_PROFILE ??= '1';
+
+const __filename   = fileURLToPath(import.meta.url),
+      __dirname    = path.dirname(__filename),
+      REPO_ROOT    = path.resolve(__dirname, '../..'),
+      PORT         = Number(process.env.DEVINDEX_E2E_PORT || 8090),
+      launchArgs   = activeLaunchArgs(),
+      needsGlProbe = requiresGlProbe(launchArgs);
 
 /**
  * The engine ships an e2e config, and this repository deliberately does NOT reuse it — the same
@@ -36,6 +60,11 @@ const __filename = fileURLToPath(import.meta.url),
  *
  * This is a local / pre-merge suite. Run it before touching the grid, the store or the scroll path.
  */
+const browserProject = {
+    name: 'chromium',
+    use : {channel: 'chrome', launchOptions: {args: launchArgs}}
+};
+
 export default defineConfig({
     testDir      : path.join(__dirname, 'e2e'),
     outputDir    : path.join(__dirname, 'test-results/e2e'),
@@ -52,13 +81,14 @@ export default defineConfig({
     globalSetup  : path.join(__dirname, 'e2e/globalSetup.mjs'),
 
     use: {
-        baseURL : `http://localhost:${PORT}`,
+        baseURL      : `http://localhost:${PORT}`,
         // Local Google Chrome rather than the bundled build: `npm ci` here does not run
         // `playwright install`, so the bundled chromium is absent on a fresh checkout and the run
         // fails at launch with a missing-executable error that looks like a config fault.
-        channel : 'chrome',
-        trace   : 'on-first-retry',
-        viewport: {width: 1920, height: 1080}
+        channel      : 'chrome',
+        launchOptions: {args: launchArgs},
+        trace        : 'on-first-retry',
+        viewport     : {width: 1920, height: 1080}
     },
 
     webServer: {
@@ -72,5 +102,23 @@ export default defineConfig({
         // NEVER reuse: an already-listening server from another clone satisfies the readiness URL
         // and then serves the wrong tree to every spec — false reds and, worse, false greens.
         reuseExistingServer: false
-    }
+    },
+
+    // Boot gate. The engine profile above CLAIMS hardware acceleration; this observes that the flags
+    // actually resolved to it, before a single benchmark attributes a number to a GPU it may not be
+    // using. A canvas-per-mounted-cell app silently falling back to software rendering still passes
+    // every assertion here — it just measures something else, which is the failure mode a green
+    // suite cannot tell you about.
+    //
+    // It launches with the SAME args as the suite; probing a differently-configured browser would
+    // prove nothing about this one.
+    projects: needsGlProbe ? [{
+        name     : 'gl-probe',
+        testMatch: /gl\.setup\.mjs$/,
+        use      : {channel: 'chrome', launchOptions: {args: launchArgs}}
+    }, {
+        ...browserProject,
+        testIgnore  : /gl\.setup\.mjs$/,
+        dependencies: ['gl-probe']
+    }] : [{...browserProject, testIgnore: /gl\.setup\.mjs$/}]
 });

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -1,0 +1,76 @@
+import {defineConfig}  from '@playwright/test';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url),
+      __dirname  = path.dirname(__filename),
+      REPO_ROOT  = path.resolve(__dirname, '../..'),
+      PORT       = Number(process.env.DEVINDEX_E2E_PORT || 8090);
+
+/**
+ * The engine ships an e2e config, and this repository deliberately does NOT reuse it — the same
+ * structural reasoning `playwright.config.unit.mjs` records for the unit suite, plus one more:
+ *
+ * 1. Its `testDir` resolves against its own `__dirname`, so it would collect the ENGINE's specs out
+ *    of `node_modules` rather than this workspace's.
+ * 2. It carries a GPU-probe project, a benchmark system-info reporter and a Chroma-aware template
+ *    resolver — infrastructure for measuring the engine, none of which these specs consult.
+ * 3. Its `globalSetup` builds theme assets relative to ITS OWN location, which out of
+ *    `node_modules` is the wrong `dist/`. See `e2e/globalSetup.mjs`.
+ *
+ * What follows is the minimum these five specs actually need.
+ *
+ * ## Why this suite is NOT wired into CI, and must not be
+ *
+ * Not an oversight, and not a TODO. Every spec here drives the real grid, which needs the real
+ * `users.jsonl` — and that file is gitignored (`.gitignore:26`, zero tracked) while
+ * `buildScripts/pullDevIndexData.mjs:49` deliberately skips its fetch when `CI` is set, because the
+ * collection workflow fetches the index itself. So under CI there is no data, the body renders no
+ * rows, and all eleven cases fail for a reason that has nothing to do with the code.
+ *
+ * Two of them are also wall-clock benchmarks. `.github/workflows/ci.yml` already records the same
+ * hazard one job up, excluding the profiling specs because a shared runner can double their budget —
+ * "a regression report for something that did not regress". That reasoning applies here harder, not
+ * less. The engine repository reaches the same conclusion by the same route: nothing in its
+ * workflows runs its e2e suite either.
+ *
+ * This is a local / pre-merge suite. Run it before touching the grid, the store or the scroll path.
+ */
+export default defineConfig({
+    testDir      : path.join(__dirname, 'e2e'),
+    outputDir    : path.join(__dirname, 'test-results/e2e'),
+    // Serial by construction: two of these specs are wall-clock benchmarks, and a parallel worker
+    // stealing CPU reports as a product regression that does not exist. The unit config isolates its
+    // two profiling specs into a serialized project for exactly this reason; here every spec either
+    // measures timing or drives a real pointer gesture, so the whole suite is the serial case.
+    fullyParallel: false,
+    workers      : 1,
+    forbidOnly   : !!process.env.CI,
+    retries      : 0,
+    timeout      : 120000,
+    reporter     : [['list'], ['json', {outputFile: path.join(__dirname, 'test-results/e2e/test-results.json')}]],
+    globalSetup  : path.join(__dirname, 'e2e/globalSetup.mjs'),
+
+    use: {
+        baseURL : `http://localhost:${PORT}`,
+        // Local Google Chrome rather than the bundled build: `npm ci` here does not run
+        // `playwright install`, so the bundled chromium is absent on a fresh checkout and the run
+        // fails at launch with a missing-executable error that looks like a config fault.
+        channel : 'chrome',
+        trace   : 'on-first-retry',
+        viewport: {width: 1920, height: 1080}
+    },
+
+    webServer: {
+        // `globalSetup` runs AFTER `webServer` starts, so the theme build is invoked here as well —
+        // the hook then re-checks and no-ops. No `--prefix`: the command must serve the clone it was
+        // launched from.
+        command            : `node ./test/playwright/e2e/globalSetup.mjs && npm run server-start -- --port ${PORT} --no-open`,
+        cwd                : REPO_ROOT,
+        url                : `http://localhost:${PORT}/apps/devindex/index.html`,
+        timeout            : 300000,
+        // NEVER reuse: an already-listening server from another clone satisfies the readiness URL
+        // and then serves the wrong tree to every spec — false reds and, worse, false greens.
+        reuseExistingServer: false
+    }
+});

--- a/test/playwright/unit/app/devindex/StorageWorkingSetHydration.spec.mjs
+++ b/test/playwright/unit/app/devindex/StorageWorkingSetHydration.spec.mjs
@@ -48,14 +48,26 @@ test.describe('DevIndex Storage — hydrating the published working set', () => 
     // filesystem at all, which is what makes the cause easy to misread as flake.
     test.describe.configure({mode: 'serial'});
 
-    const MANIFEST_FILE = config.paths.workingSetManifest.slice(config.paths.workingSetManifest.lastIndexOf('/') + 1);
+    const MANIFEST_FILE = config.paths.workingSetManifest.slice(config.paths.workingSetManifest.lastIndexOf('/') + 1),
 
-    let originalFetch, originalWriteAtomic, writes;
+          // Captured at collection time, which is the only moment this file has not already shadowed
+          // the singleton — `beforeEach` installs the stub before any test body runs, so a reading
+          // taken inside a test would compare the stub against itself and pass regardless.
+          PRISTINE_HAS_OWN = Object.hasOwn(Storage, 'writeAtomic'),
+          PRISTINE_METHOD  = Storage.writeAtomic;
+
+    let originalFetch, writeAtomicDescriptor, writes;
 
     test.beforeEach(() => {
-        originalFetch       = globalThis.fetch;
-        originalWriteAtomic = Storage.writeAtomic.bind(Storage);
-        writes              = [];
+        originalFetch = globalThis.fetch;
+        writes        = [];
+
+        // The DESCRIPTOR, not the function. `writeAtomic` is inherited from the prototype, so
+        // `Storage.writeAtomic.bind(Storage)` followed by an assignment back does not restore
+        // anything — it converts an inherited method into an OWN property holding a bound copy with
+        // a different identity, and leaves that on the singleton for every later spec in the process.
+        // Capturing the descriptor lets teardown put the object back in the state it was found.
+        writeAtomicDescriptor = Object.getOwnPropertyDescriptor(Storage, 'writeAtomic') ?? null;
 
         // Adoption is observed rather than performed: the property under test is WHICH writes happen
         // and whether any happen at all, not what lands on disk. `StorageWriteDirectory.spec.mjs`
@@ -70,8 +82,16 @@ test.describe('DevIndex Storage — hydrating the published working set', () => 
     });
 
     test.afterEach(() => {
-        globalThis.fetch    = originalFetch;
-        Storage.writeAtomic = originalWriteAtomic;
+        globalThis.fetch = originalFetch;
+
+        if (writeAtomicDescriptor) {
+            Object.defineProperty(Storage, 'writeAtomic', writeAtomicDescriptor)
+        } else {
+            // There was no own property before, so removing this file's shadow is what restores the
+            // inherited method — with its original identity, not an equivalent copy.
+            delete Storage.writeAtomic
+        }
+
         delete Storage.hydration
     });
 
@@ -210,6 +230,27 @@ test.describe('DevIndex Storage — hydrating the published working set', () => 
         } finally {
             console.warn = originalWarn
         }
+    });
+
+    test('this file leaves the Storage singleton exactly as it found it', async () => {
+        // The isolation itself, asserted rather than assumed. Every case here shadows a method on a
+        // module singleton, and the failure mode is silent: a teardown that assigns an equivalent
+        // function back still leaves an OWN property where an inherited one was, which the next spec
+        // in the process inherits. This case runs the full teardown path and checks the object, not
+        // the behaviour — equivalent call behaviour is exactly what hid the problem.
+        stubNetwork();
+        await Storage.hydrateWorkingSet();
+
+        // Mirror exactly what afterEach does, so the assertion covers the real restore path rather
+        // than a re-implementation of it.
+        writeAtomicDescriptor
+            ? Object.defineProperty(Storage, 'writeAtomic', writeAtomicDescriptor)
+            : delete Storage.writeAtomic;
+
+        expect(Object.hasOwn(Storage, 'writeAtomic'), 'ownership is restored, not merely re-assigned')
+            .toBe(PRISTINE_HAS_OWN);
+        expect(Storage.writeAtomic, 'the ORIGINAL method identity is restored, not an equivalent copy')
+            .toBe(PRISTINE_METHOD)
     });
 
     test('hydration runs once per process, however many callers ask for it', async () => {

--- a/test/playwright/unit/app/devindex/StorageWorkingSetHydration.spec.mjs
+++ b/test/playwright/unit/app/devindex/StorageWorkingSetHydration.spec.mjs
@@ -1,0 +1,228 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'DevIndexStorageWorkingSetHydrationTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../node_modules/neo.mjs/src/Neo.mjs';
+import * as core      from '../../../../../node_modules/neo.mjs/src/core/_export.mjs';
+import config         from '../../../../../apps/devindex/services/config.mjs';
+import Storage        from '../../../../../apps/devindex/services/Storage.mjs';
+
+/**
+ * @summary The read side: fetching the published working set, verifying it, and adopting it as one unit.
+ *
+ * This is the path that decides what the pipeline believes its previous state was. It runs before any
+ * collection stage, it overwrites nine local files, and until now nothing tested it.
+ *
+ * The engine repository still carries `StoragePublishedIndex.spec.mjs`, which pins the SUPERSEDED
+ * single-file `publishedIndex` contract — `config.publishedIndex` and `config.paths.indexProvenance`
+ * do not exist here. So this is not that spec ported: the properties are its properties, re-derived
+ * against the shape that actually runs, where one file became nine and provenance moved into a
+ * fetched manifest.
+ *
+ * ## Why the all-or-nothing property is the one that matters
+ *
+ * `workingSetMembers()` includes `blocklist`, and `Storage`'s own docblock says why: a user opts out,
+ * `addToBlocklist` records it, and if that file is not carried with the set the decision does not
+ * survive the run — while the closing comment has already told them they were removed. A half-adopted
+ * set is therefore not a stale cache, it is a privacy failure, and `fetchAndAdoptWorkingSet` defends
+ * against it by writing nothing until every member has been fetched and verified.
+ *
+ * That defence is invisible to a test that only checks the happy path, which is what makes it worth
+ * pinning: it holds today, it is one early `writeAtomic` away from not holding, and the symptom would
+ * be silent.
+ */
+test.describe('DevIndex Storage — hydrating the published working set', () => {
+    // Serial by necessity, not preference. Every case here swaps members on the `Storage` SINGLETON —
+    // `globalThis.fetch`, `writeAtomic`, the memoized `hydration` — and the unit config runs
+    // `fullyParallel: true`. Under parallel execution one case's `afterEach` restores the real
+    // `writeAtomic` while another is still mid-hydration, and the real writer then fires against a
+    // gitignored data directory: `ENOENT ... optout-sync.json.tmp`. Observed, not hypothetical — it is
+    // what the first run of this file did, and it surfaced in a SYNCHRONOUS case that touches no
+    // filesystem at all, which is what makes the cause easy to misread as flake.
+    test.describe.configure({mode: 'serial'});
+
+    const MANIFEST_FILE = config.paths.workingSetManifest.slice(config.paths.workingSetManifest.lastIndexOf('/') + 1);
+
+    let originalFetch, originalWriteAtomic, writes;
+
+    test.beforeEach(() => {
+        originalFetch       = globalThis.fetch;
+        originalWriteAtomic = Storage.writeAtomic.bind(Storage);
+        writes              = [];
+
+        // Adoption is observed rather than performed: the property under test is WHICH writes happen
+        // and whether any happen at all, not what lands on disk. `StorageWriteDirectory.spec.mjs`
+        // already owns the real write.
+        Storage.writeAtomic = async (localPath, text) => {
+            writes.push({localPath, text})
+        };
+
+        // `hydrateWorkingSet()` memoizes into `this.hydration`, so a residue from a previous case
+        // would make every later case assert against the first case's network.
+        delete Storage.hydration
+    });
+
+    test.afterEach(() => {
+        globalThis.fetch    = originalFetch;
+        Storage.writeAtomic = originalWriteAtomic;
+        delete Storage.hydration
+    });
+
+    /**
+     * Serves the network per URL. Returns the recorded requests so a case can assert the CALL —
+     * which URLs were built and in what shape — rather than only the outcome.
+     *
+     * @param {Object}   options
+     * @param {Object}   [options.manifest]  body for the manifest request; `null` serves a 404
+     * @param {Function} [options.member]    `({file}) => ({ok, status, text})` for each member
+     * @returns {Object[]} recorded `{url}` entries
+     */
+    const stubNetwork = ({manifest = null, member = () => ({ok: true, status: 200, text: 'x'})} = {}) => {
+        const calls = [];
+
+        globalThis.fetch = async (url, init) => {
+            calls.push({url, init});
+
+            const file = url.slice(url.lastIndexOf('/') + 1);
+
+            if (file === MANIFEST_FILE) {
+                return manifest === null
+                    ? {ok: false, status: 404, text: async () => ''}
+                    : {ok: true, status: 200, text: async () => JSON.stringify(manifest)};
+            }
+
+            const {ok = true, status = 200, text = 'x', throws} = member({file});
+
+            if (throws) throw new Error(throws);
+
+            return {ok, status, text: async () => text}
+        };
+
+        return calls
+    };
+
+    test('every member is fetched from the single declared base URL, never a reassembled one', async () => {
+        const calls = stubNetwork();
+
+        await Storage.hydrateWorkingSet();
+
+        const {baseUrl} = config.publishedWorkingSet,
+              memberCalls = calls.filter(({url}) => !url.endsWith(MANIFEST_FILE));
+
+        expect(memberCalls.length, 'one request per working-set member').toBe(Storage.workingSetMembers().length);
+
+        memberCalls.forEach(({url}) => {
+            expect(url.startsWith(baseUrl), `built from the declared base URL: ${url}`).toBe(true);
+            // A reassembled host is the failure this guards: the base is declared once, and every
+            // member URL must be that literal plus a basename, with nothing between them.
+            expect(url.slice(baseUrl.length).includes('/'), `no path segment injected: ${url}`).toBe(false)
+        })
+    });
+
+    test('the blocklist travels with the set — an opt-out that is not carried does not survive the run', () => {
+        const keys = Storage.workingSetMembers().map(({key}) => key);
+
+        // Named individually rather than by count: the regression this guards is a member being
+        // dropped because it is small, and a count assertion passes as long as SOMETHING replaces it.
+        ['blocklist', 'optoutSync', 'optinSync', 'allowlist', 'users', 'tracker', 'visited', 'threshold', 'failed']
+            .forEach(key => expect(keys, `${key} is part of the working set`).toContain(key))
+    });
+
+    test('a non-2xx on any member adopts NOTHING — not even the members already fetched', async () => {
+        stubNetwork({member: ({file}) => file.startsWith('visited') ? {ok: false, status: 503} : {text: 'ok'}});
+
+        await Storage.hydrateWorkingSet();
+
+        expect(writes, 'a rejected set leaves every local file untouched').toEqual([])
+    });
+
+    test('a member that throws adopts NOTHING, and the failure names the file', async () => {
+        const warnings = [];
+        const originalWarn = console.warn, originalError = console.error;
+
+        console.warn = (...args) => warnings.push(args.join(' '));
+        console.error = (...args) => warnings.push(args.join(' '));
+
+        try {
+            stubNetwork({member: ({file}) => file.startsWith('tracker') ? {throws: 'ECONNRESET'} : {text: 'ok'}});
+
+            await Storage.hydrateWorkingSet();
+
+            expect(writes, 'a transport failure leaves every local file untouched').toEqual([]);
+            expect(warnings.join('\n'), 'the retreat is audible and names the file')
+                .toContain('tracker')
+        } finally {
+            console.warn = originalWarn;
+            console.error = originalError
+        }
+    });
+
+    test('a digest mismatch adopts NOTHING, even though every fetch succeeded', async () => {
+        const members = Storage.workingSetMembers(),
+              digests = {};
+
+        // Every member matches except one, so the ONLY thing failing the set is the comparison —
+        // not a transport error, not a missing file.
+        members.forEach(({key}) => {digests[key] = Storage.digestOf('ok')});
+        digests[members[0].key] = 'deadbeefdeadbeefdeadbeef';
+
+        stubNetwork({manifest: {digests}, member: () => ({text: 'ok'})});
+
+        await Storage.hydrateWorkingSet();
+
+        expect(writes, 'a set that fails verification is not adopted in part').toEqual([])
+    });
+
+    test('a manifest whose digests all match IS adopted, so the mismatch case above is not vacuous', async () => {
+        const digests = {};
+
+        Storage.workingSetMembers().forEach(({key}) => {digests[key] = Storage.digestOf('ok')});
+
+        stubNetwork({manifest: {digests}, member: () => ({text: 'ok'})});
+
+        await Storage.hydrateWorkingSet();
+
+        expect(writes.length, 'a verified set adopts every member').toBe(Storage.workingSetMembers().length)
+    });
+
+    test('absence of a manifest is not mismatch — the set is adopted, and the warning says it is unverified', async () => {
+        const warnings = [];
+        const originalWarn = console.warn;
+
+        console.warn = (...args) => warnings.push(args.join(' '));
+
+        try {
+            stubNetwork({manifest: null, member: () => ({text: 'ok'})});
+
+            await Storage.hydrateWorkingSet();
+
+            expect(writes.length, 'a deployment with nothing published still hydrates')
+                .toBe(Storage.workingSetMembers().length);
+            expect(warnings.join('\n'), 'and it says so, loudly, rather than adopting silently')
+                .toContain('UNVERIFIED')
+        } finally {
+            console.warn = originalWarn
+        }
+    });
+
+    test('hydration runs once per process, however many callers ask for it', async () => {
+        const calls = stubNetwork();
+
+        await Promise.all([
+            Storage.hydrateWorkingSet(),
+            Storage.hydrateWorkingSet(),
+            Storage.hydrateWorkingSet()
+        ]);
+
+        const expected = Storage.workingSetMembers().length + 1; // members + the manifest
+
+        expect(calls.length, 'three callers, one network pass').toBe(expected)
+    });
+});


### PR DESCRIPTION
Part of neomjs/neo#17422 · unblocks neomjs/neo#17421 · which unblocks neomjs/neo#17376

Five e2e specs in `neomjs/neo` drive `/apps/devindex/` **exclusively** and had nowhere to go — this repository had one Playwright config, one script, and no `e2e/` directory. They move here so the app's tests live with the app.

Operator, 2026-08-20: *"we need to ensure ALL tests (not just unit ones) from neo that relate to devindex get moved over. once this is done, we can remove it from the neo repo. when that is done, we can finally reduce the bloated 5GB neo history."*

Evidence: L2 (the suite runs green here, serving the app from this clone) → L2 required (the property is "do these specs pass against this repo's app", which the run answers directly).

## Deliberately small

None of the five imports the engine's `fixtures.mjs` — the 682-line Neural Link fixture. They take plain `@playwright/test`, and only `GridScrollBenchmark` pulls one helper:

| ported | lines |
|---|---|
| `e2e/utils/browser-test-helpers.mjs` | 135 |
| `playwright.config.e2e.mjs` | new |
| `e2e/globalSetup.mjs` | new |

Porting `fixtures.mjs` "for completeness" would hand this repo the whole-Brain import cost that neomjs/neo#17369 exists to remove, for zero specs that use it.

## The engine's e2e config is not reused

Same structural reasoning `playwright.config.unit.mjs` already records for the unit suite — its `testDir` resolves against its own `__dirname` and would collect the *engine's* specs out of `node_modules` — plus two more, both verified rather than assumed:

- its `globalSetup` derives theme targets from `import.meta.dirname`, so out of `node_modules` it would build into `node_modules/neo.mjs/dist/` and never this workspace's;
- it is **absent from the published version this repo consumes**.

So theme assurance is written here instead.

**Why theme assurance is load-bearing and not boilerplate:** without `dist/development/css`, the app boots, the header renders all 37 columns, and the footer cheerfully reports `Visible Rows: 50,000` — while the body computes to `height: 0` and virtualization derives no rows. Every row assertion fails, and it reads exactly like an engine or data-layer fault. It is a setup gap. The build runs from `globalSetup` **and** as the first web-server step, because Playwright starts `webServer` before `globalSetup`.

## Not wired into CI — deliberately, not a TODO

Every spec drives the real grid, which needs the real `users.jsonl`. That file is gitignored (`.gitignore:26`, zero tracked) and `buildScripts/pullDevIndexData.mjs:49` **skips its fetch when `CI` is set** — *"the pipeline fetches the index itself"*. Under CI there would be no data, no rows, and eleven failures unrelated to the code.

Two are also wall-clock benchmarks. `.github/workflows/ci.yml` already names that hazard one job up when it excludes the profiling specs — *"a regression report for something that did not regress"*. That applies here harder, not less.

And the engine reaches the same conclusion by the same route: **nothing in `neomjs/neo`'s workflows runs its e2e suite either.** Verified, not assumed.

The reasoning lives in the config docblock so it is not re-litigated as an oversight.

## Test Evidence

First run, no retries, app served from this clone:

```
✓  GridProfile — Mobile / Laptop / Desktop            3
✓  GridScrollBenchmark — Mobile / Laptop / Desktop    3
✓  ThumbDrag — stale render + horizontal virtualization 2
✓  ThumbDragDevIndex — telemetry + horizontal drag    2
✓  ThumbDragPause — pinning across a pause            1
11 passed (1.0m)
```

The benchmarks measure **the same app on the same fixture** they measure today, so the series stays continuous — this move introduces no re-baseline.

## Base branch

Targets `main` per the operator's 2026-08-20 direction and the precedent set by neomjs/devindex#3.

## Second arm — read-path coverage, added after the first review round

This PR now carries **both** arms of neomjs/neo#17422. The section above describes the e2e custody move; this is the coverage half, and the body previously excluded it because it did not yet exist here.

`StorageWorkingSetHydration.spec.mjs` — 9 cases — covers `Storage#fetchAndAdoptWorkingSet`, the path that decides what every run believes its previous state was. It runs before any collection stage and overwrites nine local files. Counting `publishedWorkingSet` / `baseUrl` / `fetch(` across all nine pre-existing specs returned **zero**.

**It is not neo's `StoragePublishedIndex.spec.mjs` ported.** That spec pins the superseded single-file contract; `config.publishedIndex` and `config.paths.indexProvenance` do not exist here. One file became nine members, and provenance moved into a fetched manifest. The properties are its properties, re-derived against the shape that runs.

| case | property |
|---|---|
| single declared base URL | every member built from the literal, no injected path segment |
| the nine members | named **individually** — a count still passes when one is dropped and another added |
| non-2xx / transport throw / digest mismatch | each adopts **nothing** |
| a matching manifest | adopts everything, so the mismatch case is not vacuous |
| absent manifest | adopts, with an audible `UNVERIFIED` warning rather than silently |
| memoization | three concurrent callers, one network pass |
| singleton isolation | this file leaves `Storage` exactly as it found it |

**The load-bearing property is a privacy one.** `workingSetMembers()` includes `blocklist`, and `Storage`'s own docblock says why: a user opts out, `addToBlocklist` records it, and if the file is not carried the decision does not survive the run — while the closing comment has already told them they were removed. A half-adopted set is not a stale cache.

**Mutation-verified, twice.** Moving the write inside the fetch loop — one line, the plausible regression — makes the non-2xx case fail at once. And restoring `writeAtomic` by `bind`-and-reassign makes the isolation case fail with *"ownership is restored, not merely re-assigned"*, which is the defect the reviewer found in the first version of this arm.

**Exact-head unit evidence:** `56 passed` on the full unit suite at `--project=unit`.

### Two isolation defects this arm shipped and repaired

Both are recorded because each presented as something other than its cause.

1. **A race that reported in the wrong test.** The first run failed a *synchronous* case touching no filesystem, with `ENOENT … optout-sync.json.tmp`. Every case swaps members on the `Storage` **singleton** while the unit config runs `fullyParallel: true`. Fixed with `describe.configure({mode: 'serial'})`, verified across repeat runs — a race that heals on retry is not fixed.
2. **A teardown that restored nothing.** `Storage.writeAtomic.bind(Storage)` assigned back converts an *inherited* method into an *own* bound copy with a different identity, leaving a permanent shadow for every later spec in the process. Now captures and restores the property **descriptor**, and the isolation case above asserts it against a pristine reading taken at collection time — the only moment this file has not already shadowed the singleton.

## Out of Scope

- Deleting these specs from `neomjs/neo` — happens only after this is green here, on neomjs/neo#17422
- Repairing `GridScrollBenchmark`'s scroll target and dormant jank instrument — both predate this move and are marked `fixme`; a behaviour change belongs in its own reviewable commit
- The GPU-probe project's engine benchmark system-info reporter — engine measurement infrastructure these specs never consult

Authored by Grace (Claude Opus 5, Claude Code). Session 3e4f33e0-fb23-4a61-a2a0-7f396950f3d6.

