### PR TITLE
feat(ci): adopt shared PR baseline (#11)

### DIFF
--- a/.github/workflows/shared-pr-baseline.yml
+++ b/.github/workflows/shared-pr-baseline.yml
@@ -1,0 +1,17 @@
+# DevIndex owns only the event trigger and immutable Skills coordinate. The called workflow owns
+# base admission and materialization, so their implementation cannot drift in this consumer.
+
+name: Shared PR Baseline
+
+permissions:
+  contents: read
+
+# Deliberately unfiltered: once these jobs become required contexts, every PR must emit a terminal
+# result. The called PR-base job rejects an unsupported base instead of leaving a context pending.
+on:
+  pull_request:
+
+jobs:
+  baseline:
+    name: Shared PR Baseline
+    uses: neomjs/neo-agent-skills/.github/workflows/reusable-pr-baseline.yml@72965ba56b43e898d566af97f8ab277b28beb96b


### PR DESCRIPTION
Resolves #11
Related: neomjs/neo-agent-skills#14

DevIndex now calls the canonical Skills PR baseline through one 17-line workflow pinned to immutable merge commit `72965ba56b43e898d566af97f8ab277b28beb96b`. The consumer owns only the all-PR trigger, read-only permission, stable caller job, and pin; product CI remains unchanged.

Evidence: L2 (GitHub executed both called jobs against this DevIndex checkout; existing product CI also stayed green) → L2 required (live cross-repository caller behavior). Residual: none.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | `shared-pr-baseline.yml` pins exactly `72965ba56b43e898d566af97f8ab277b28beb96b`. |
| AC-2 | The caller declares unfiltered `pull_request:` and no `branches:` key. |
| AC-3 | Top-level permissions contain only `contents: read`. |
| AC-4 | The caller has one `uses:` job and contains no `steps`, checkout, Node, install, or materializer implementation. |
| AC-5 | `Shared PR Baseline / PR base` passed in 2s and `Shared PR Baseline / Skills materialized` passed in 23s on head `f3635c3`. |
| AC-6 | The branch changes one workflow file; existing product CI and tests have zero diff. |

## Deltas from ticket

None substantive.

## Test Evidence

The live reusable-workflow integration runs in CI; no product test source is changed.

## Post-Merge Validation

No post-merge-only validation. Required-context settings remain the separate `neomjs/neo#17783` enforcement lane.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 5ea998d3-e1ed-4214-8472-c337ff247403.
